### PR TITLE
Fixing assumption bug

### DIFF
--- a/roundingsat.cc
+++ b/roundingsat.cc
@@ -338,7 +338,7 @@ void undoOne(){
 	trail.pop_back();
 	Level[l] = -1;
 	phase[abs(l)]=l;
-	while(!trail_lim.empty() && trail_lim.back() == (int)trail.size())trail_lim.pop_back();
+	while(!trail_lim.empty() && trail_lim.back() >= (int)trail.size())trail_lim.pop_back();
 	Reason[l] = CRef_Undef;
 	insertVarOrder(abs(l));
 }


### PR DESCRIPTION
What went wrong was that line `[1211] if(solve(aux))` ran to satisfaction,
but the last level was a dummy level (which can happen if all non-aux
literals are propagated at level 0). Hence
`trail_lim.back()==trail.size()` when the program continues to `[1231]
backjumpTo(0)`. The backjump first removes a literal from the trail, and
then checks `[341] trail_lim.back()==trail.size()`, which no longer holds.
So the `trail_lim` is not reduced, but the trail is, eventually leading to
an empty trail on a non-zero decision level, failing `[336]
assert(!trail.empty())`.